### PR TITLE
change plotting

### DIFF
--- a/octave/tm/tmrepl.m
+++ b/octave/tm/tmrepl.m
@@ -36,17 +36,9 @@ function tmrepl()
     eval (__r, "tmlasterr");
 
     if disp_ans
-      global TM_OCTAVE_PLOT_DIGEST;
-      
-      updated_digest= hash ("md5", serialize (get(gcf())));
-      if !strcmp (TM_OCTAVE_PLOT_DIGEST, updated_digest)
-        TM_OCTAVE_PLOT_DIGEST= updated_digest;
-        plotted= tmplot (); ## call TeXmacs plotting interface
-        if plotted
-          disp_ans= false;
-        endif
-      endif
-    endif 
+      tmplot (); ## call TeXmacs plotting interface
+      clf()
+    endif
 
     if disp_ans && isnewans (ans)
       tmdisp (ans);


### PR DESCRIPTION
An attempt to resolve issue #6. tmplot already checks for an empty plot, so do we need TM_OCTAVE_PLOT_DIGEST?

Note that `gcf()` has the side effect of creating an empty plot if none is open, `get (groot, "currentfigure");` doesn't do this
Found this in the [Octave docs](https://octave.org/doc/v6.1.0/Graphics-Objects.html).